### PR TITLE
fix: use /v1a/version as healthcheck path

### DIFF
--- a/charts/hathor-fullnode/Chart.yaml
+++ b/charts/hathor-fullnode/Chart.yaml
@@ -5,7 +5,7 @@ maintainers:
 - email: contact@hathor.network
   name: Hathor Team
 type: application
-version: 0.3.1
-appVersion: "v0.42.0"
+version: 0.3.2
+appVersion: "v0.45.0"
 sources:
   - https://github.com/HathorNetwork/hathor-core

--- a/charts/hathor-fullnode/templates/statefulset.yaml
+++ b/charts/hathor-fullnode/templates/statefulset.yaml
@@ -96,18 +96,20 @@ spec:
               protocol: TCP
           startupProbe:
             httpGet:
-              path: /v1a/status
+              path: /v1a/version
               port: http
             failureThreshold: 48
             periodSeconds: 300
           livenessProbe:
             httpGet:
-              path: /v1a/status
+              path: /v1a/version
               port: http
+            failureThreshold: 5
           readinessProbe:
             httpGet:
-              path: /v1a/status
+              path: /v1a/version
               port: http
+            failureThreshold: 5
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
### Acceptance Criteria
- We should use /v1a/version for healthchecking the fullnode
- We should use v0.45.0 as the default version of hathor-core