### PR TITLE
fix: remove liveness probe

### DIFF
--- a/charts/hathor-fullnode/Chart.yaml
+++ b/charts/hathor-fullnode/Chart.yaml
@@ -5,7 +5,7 @@ maintainers:
 - email: contact@hathor.network
   name: Hathor Team
 type: application
-version: 0.3.2
-appVersion: "v0.45.0"
+version: 0.3.3
+appVersion: "v0.46.0"
 sources:
   - https://github.com/HathorNetwork/hathor-core

--- a/charts/hathor-fullnode/templates/statefulset.yaml
+++ b/charts/hathor-fullnode/templates/statefulset.yaml
@@ -100,11 +100,6 @@ spec:
               port: http
             failureThreshold: 48
             periodSeconds: 300
-          livenessProbe:
-            httpGet:
-              path: /v1a/version
-              port: http
-            failureThreshold: 5
           readinessProbe:
             httpGet:
               path: /v1a/version


### PR DESCRIPTION
### Acceptance Criteria
- We shouldn't have a liveness probe in the hathor-core helm chart

### Motivation
The liveness probe isn't really needed. It was causing the fullnode to restart because of delays in the API.

Relying only on the default liveness probe of Kubernetes, which is to check if the PID 1 is still running in the container, seems better in this case.